### PR TITLE
Scanner challenge 4 - comment blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,9 @@ Most of the time, we "consume" a character when reading the source code (i.e. th
 
 It makes much more sense now why an identifier such as a variable can't start with a number of symbol (other than `_`) in most languages. It would add a lot more complexity to identifying numeric literals. If I add `42x` to my source code, should this be flagged as a Lexical Error because the numeric literal contains an alpha character? Or should this be interpreted as an identifier by that name?
 
+### Challenge 4 - nested block comments
+
+I chose to take on the challenge of nested C-style block comments (`/* ... */`). I counted the occurrences of `/*` to keep track of how many layers of nesting I'm in at any given point. The tricky thing here is to make sure that I handle calling an extra `advance()` when my block comment counter gets to zero so that I consume the final `/`. Otherwise, the Scanner will add an errant `SLASH` token to the TokenArray of the program.
+
+I, personally, find the nested comment blocks to be confusing when eventually writing JLox. It makes more sense for any instance of `*/` to end the block comment regardless of how many instances of `/*` there were. But I will leave the nested logic in my implementation for now.
+

--- a/com/craftinginterpreters/lox/Scanner.java
+++ b/com/craftinginterpreters/lox/Scanner.java
@@ -18,6 +18,7 @@ class Scanner {
     private int start = 0;
     private int current = 0;
     private int line = 1;
+    private int comment_block_count = 0;
 
     Scanner(String source) {
         this.source = source;
@@ -71,6 +72,8 @@ class Scanner {
                 if (match('/')) {
                     // A comment goes until the end of the line.
                     while (peek() != '\n' && !isAtEnd()) advance();
+                } else if (match('*')) {
+                    comment_block();
                 } else {
                     addToken(SLASH);
                 }
@@ -97,6 +100,35 @@ class Scanner {
                     Lox.error(line, "Unexpected character.");
                 }
                 break;
+        }
+    }
+
+
+    private void comment_block() {
+        // Challenge 4; implement C-style /* ... */ comment blocks.
+        // Bonus: allow them to nest within each other.
+        // Thoughts: I need to track the count of occurrences of `/*`
+        // for nesting. I also need to track newlines, much like we do
+        // in the multi-line string logic.
+
+        comment_block_count++;
+        while (comment_block_count > 0) {
+            // first iteration will be the char immediately after 
+            // the '*' of the opening comment block
+            char c = advance();
+            if (isAtEnd()) {
+                Lox.error(line, "Unterminated comment block.");
+                return;
+            }
+            if (c == '\n') line++;
+            if (c == '/' && peek() == '*') comment_block_count++;
+            if (c == '*' && peek() == '/') {
+                comment_block_count--;
+
+                // consume the '/' in the final '*/' which closes
+                // out this instance of a block comment
+                if (comment_block_count == 0) advance();
+            }
         }
     }
 

--- a/jloc_test_scripts/ch04_challenge04_a.jloc
+++ b/jloc_test_scripts/ch04_challenge04_a.jloc
@@ -1,0 +1,11 @@
+/*
+This is a block comment!
+Line numbers should still be counted though...
+*/
+
+var x = 199;
+var y = 42;
+var mybool;
+if (x >= y) {
+    mybool = true;
+}

--- a/jloc_test_scripts/ch04_challenge04_b.jloc
+++ b/jloc_test_scripts/ch04_challenge04_b.jloc
@@ -1,0 +1,14 @@
+/*
+This is a block comment!
+    
+    /*
+    This code block is nested and won't end the parent/outer
+    code block!
+    */
+
+So these should still be commented out below here
+var x = 199;
+var y = 42;
+*/
+// @ // uncomment this line for "[line 13] Error: Unexpected character" (line number counting is working)
+var mybool = true;


### PR DESCRIPTION
I implemented the C-style, nested comment blocks per [Challenge 4](https://craftinginterpreters.com/scanning.html#challenges) on the Scanner chapter.